### PR TITLE
Fix url scope for new_link

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        foreman-core-branch: [2.1-stable, develop]
-        ruby-version: [2.5, 2.6]
+        foreman-core-branch: [2.3-stable, develop]
+        ruby-version: [2.6]
         node-version: [12]
     steps:
       - run: sudo apt-get install build-essential libcurl4-openssl-dev zlib1g-dev libpq-dev

--- a/app/views/foreman_statistics/trends/index.html.erb
+++ b/app/views/foreman_statistics/trends/index.html.erb
@@ -1,6 +1,6 @@
 <%= javascript 'charts' %>
 <% title _("Trends") %>
-<% title_actions new_link(_("Add Trend Counter")),
+<% title_actions new_link(_("Add Trend Counter"), engine: foreman_statistics),
                  documentation_button('4.1.3Trends') %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">

--- a/app/views/foreman_statistics/trends/welcome.html.erb
+++ b/app/views/foreman_statistics/trends/welcome.html.erb
@@ -7,6 +7,6 @@
   <p><%= _("Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts.") %></p>
   <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.1.3Trends")%></p>
   <div class="blank-slate-pf-main-action">
-    <%= new_link(_("Add Trend Counter"), :class => 'btn-lg') %>
+    <%= new_link(_("Add Trend Counter"), { engine: foreman_statistics }, :class => 'btn-lg') %>
   </div>
 </div>

--- a/test/functional/foreman_statistics/trends_controller_test.rb
+++ b/test/functional/foreman_statistics/trends_controller_test.rb
@@ -46,14 +46,14 @@ module ForemanStatistics
         test 'should render correct per_page value' do
           get :index, params: { per_page: entries_per_page + 1 }, session: set_session_user
           assert_response :success
-          per_page_results = response.body.scan(/perPage":\d+/).first.gsub(/[^\d]/, '').to_i
+          per_page_results = response.body.scan(/perPage&quot;:(\d+)/).first.first.to_i
           assert_equal entries_per_page, per_page_results
         end
 
         test 'should render per page dropdown with correct values' do
           get :index, params: { per_page: entries_per_page + 1 }, session: set_session_user
           assert_response :success
-          assert_not_nil response.body['perPageOptions":[5,6,10,15,25,50]']
+          assert_not_nil response.body['perPageOptions&quot;:[5,6,10,15,25,50]']
         end
 
         test 'sort links should include per page param' do


### PR DESCRIPTION
In theforeman/foreman@85a3ebb22fbac6167b20635820a4ce7119f11f96 (https://github.com/theforeman/foreman/pull/8096) we have enabled the usage of engine for these.
But this brought an issue, that the scope defaults to the Core routes.
So currently we need to use the engine even if the scope would be fine by default.