### PR TITLE
Fixes #32651 - add safeguard to Environment patch

### DIFF
--- a/app/helpers/foreman_statistics/trends_helper.rb
+++ b/app/helpers/foreman_statistics/trends_helper.rb
@@ -3,9 +3,11 @@ module ForemanStatistics
     include ::CommonParametersHelper
 
     def trendable_types
-      options = { _('Environment') => 'Environment', _('Operating system') => 'Operatingsystem',
-                  _('Model') => 'Model', _('Facts') => 'FactName', _('Host group') => 'Hostgroup', _('Compute resource') => 'ComputeResource' }
       existing = ForemanTrend.types.pluck(:trendable_type)
+      options = {}
+      options = { _('Environment') => 'ForemanPuppet::Environment' } if Foreman::Plugin.find(:foreman_puppet)
+      options.merge!({ _('Operating system') => 'Operatingsystem', _('Model') => 'Model', _('Facts') => 'FactName',
+                       _('Host group') => 'Hostgroup', _('Compute resource') => 'ComputeResource' })
       options.delete_if { |_k, v| existing.include?(v) }
     end
 

--- a/app/models/concerns/foreman_statistics/compute_resource_decorations.rb
+++ b/app/models/concerns/foreman_statistics/compute_resource_decorations.rb
@@ -1,9 +1,0 @@
-module ForemanStatistics
-  module ComputeResourceDecorations
-    extend ActiveSupport::Concern
-
-    included do
-      has_many :trends, :as => :trendable, :class_name => 'ForemanStatistics::ForemanTrend'
-    end
-  end
-end

--- a/app/models/concerns/foreman_statistics/environment_decorations.rb
+++ b/app/models/concerns/foreman_statistics/environment_decorations.rb
@@ -1,9 +1,0 @@
-module ForemanStatistics
-  module EnvironmentDecorations
-    extend ActiveSupport::Concern
-
-    included do
-      has_many :trends, :as => :trendable, :class_name => 'ForemanStatistics::ForemanTrend'
-    end
-  end
-end

--- a/app/models/concerns/foreman_statistics/has_many_trends.rb
+++ b/app/models/concerns/foreman_statistics/has_many_trends.rb
@@ -1,0 +1,9 @@
+module ForemanStatistics
+  module HasManyTrends
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :trends, as: :trendable, class_name: 'ForemanStatistics::ForemanTrend', dependent: :destroy
+    end
+  end
+end

--- a/app/models/concerns/foreman_statistics/hostgroup_decorations.rb
+++ b/app/models/concerns/foreman_statistics/hostgroup_decorations.rb
@@ -1,9 +1,0 @@
-module ForemanStatistics
-  module HostgroupDecorations
-    extend ActiveSupport::Concern
-
-    included do
-      has_many :trends, :as => :trendable, :class_name => 'ForemanStatistics::ForemanTrend'
-    end
-  end
-end

--- a/app/models/concerns/foreman_statistics/model_decorations.rb
+++ b/app/models/concerns/foreman_statistics/model_decorations.rb
@@ -1,9 +1,0 @@
-module ForemanStatistics
-  module ModelDecorations
-    extend ActiveSupport::Concern
-
-    included do
-      has_many :trends, :as => :trendable, :class_name => 'ForemanStatistics::ForemanTrend'
-    end
-  end
-end

--- a/app/models/concerns/foreman_statistics/operatingsystem_decorations.rb
+++ b/app/models/concerns/foreman_statistics/operatingsystem_decorations.rb
@@ -1,9 +1,0 @@
-module ForemanStatistics
-  module OperatingsystemDecorations
-    extend ActiveSupport::Concern
-
-    included do
-      has_many :trends, :as => :trendable, :class_name => 'ForemanStatistics::ForemanTrend'
-    end
-  end
-end

--- a/app/models/foreman_statistics/trend.rb
+++ b/app/models/foreman_statistics/trend.rb
@@ -25,7 +25,9 @@ module ForemanStatistics
     end
 
     def self.build_trend(trend_params = {})
-      trend_params[:trendable_type] == 'FactName' ? FactTrend.new(trend_params) : ForemanTrend.new(trend_params)
+      params = trend_params.dup
+      params[:trendable_type] = 'ForemanPuppet::Environment' if params[:trendable_type] == 'Environment'
+      params[:trendable_type] == 'FactName' ? FactTrend.new(params) : ForemanTrend.new(params)
     end
 
     private

--- a/db/migrate/20210523143005_migrate_environments.rb
+++ b/db/migrate/20210523143005_migrate_environments.rb
@@ -1,0 +1,13 @@
+class MigrateEnvironments < ActiveRecord::Migration[6.0]
+  class FakeTrend < ApplicationRecord
+    self.table_name = 'trends'
+  end
+
+  def up
+    FakeTrend.where(trendable_type: 'Environment').update_all(trendable_type: 'ForemanPuppet::Environment')
+  end
+
+  def down
+    FakeTrend.where(trendable_type: 'ForemanPuppet::Environment').update_all(trendable_type: 'Environment')
+  end
+end

--- a/lib/foreman_statistics/engine.rb
+++ b/lib/foreman_statistics/engine.rb
@@ -87,11 +87,12 @@ module ForemanStatistics
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do
-      ::ComputeResource.include ForemanStatistics::ComputeResourceDecorations
-      ::Environment.include ForemanStatistics::EnvironmentDecorations
-      ::Hostgroup.include ForemanStatistics::HostgroupDecorations
-      ::Model.include ForemanStatistics::ModelDecorations
-      ::Operatingsystem.include ForemanStatistics::OperatingsystemDecorations
+      ::ComputeResource.include ForemanStatistics::HasManyTrends
+      ::Hostgroup.include ForemanStatistics::HasManyTrends
+      ::Model.include ForemanStatistics::HasManyTrends
+      ::Operatingsystem.include ForemanStatistics::HasManyTrends
+      '::Environment'.safe_constantize&.include ForemanStatistics::HasManyTrends
+      'ForemanPuppet::Environment'.safe_constantize&.include ForemanStatistics::HasManyTrends
       ::Setting.include ForemanStatistics::SettingDecorations
       ::Setting::General.prepend ForemanStatistics::GeneralSettingDecorations
       begin

--- a/test/functional/foreman_statistics/api/v2/trends_controller_test.rb
+++ b/test/functional/foreman_statistics/api/v2/trends_controller_test.rb
@@ -9,7 +9,7 @@ class ForemanStatistics::Api::V2::TrendsControllerTest < ActionController::TestC
   end
 
   let(:host) { FactoryBot.create(:host) }
-  let(:foreman_trend) { FactoryBot.create(:foreman_statistics_foreman_trend, :trendable_type => 'Environment', :fact_name => 'fact') }
+  let(:foreman_trend) { FactoryBot.create(:foreman_statistics_foreman_trend, :trendable_type => 'Operatingsystem', :fact_name => 'fact') }
   let(:fact_trend) { FactoryBot.create(:foreman_statistics_fact_trend, :trendable_type => 'FactName') }
   let(:os_fact) do
     FactoryBot.create(:fact_value, :value => 'fedora', :host => host,


### PR DESCRIPTION
Environment will go away, we need to have safeguard, also unify all the
patches as all of them are adding only the has_many trend relation.