### PR TITLE
Install libyaml-dev

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -13,6 +13,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get install libyaml-dev
       - uses: actions/checkout@v2
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Since Psych 5 libyaml is no longer vendored and needs to be installed system wide.