### PR TITLE
use `render template`, not `render file` to render the base layout

### DIFF
--- a/app/views/foreman_statistics/layouts/application_react.html.erb
+++ b/app/views/foreman_statistics/layouts/application_react.html.erb
@@ -11,4 +11,4 @@
   <div id="user-id" data-id="<%= User.current.id if User.current %>" ></div>
   <%= react_component('ForemanStatistics') %>
 <% end %>
-<%= render file: "layouts/base" %>
+<%= render template: "layouts/base" %>


### PR DESCRIPTION
`render file` is only to be used with absolute paths and raises the following error:

    Started GET "/foreman_statistics/statistics" for 192.168.122.1 at 2023-11-14 08:14:30 +0000
    Processing by ForemanStatistics::ReactController#index as HTML
      Rendered html template within foreman_statistics/layouts/application_react (Duration: 0.0ms | Allocations: 3)
      Rendered layout /usr/share/gems/gems/foreman_statistics-2.0.1/app/views/foreman_statistics/layouts/application_react.html.erb (Duration: 1.7ms | Allocations: 1936)
    `render file:` should be given the absolute path to a file. 'layouts/base' was given instead
    Backtrace for '`render file:` should be given the absolute path to a file. 'layouts/base' was given instead' error (ActionView::Template::Error): `render file:` should be given the absolute path
     to a file. 'layouts/base' was given instead